### PR TITLE
Fix full range value

### DIFF
--- a/AttributedStringSugar/Classes/AttributedStringSugar.swift
+++ b/AttributedStringSugar/Classes/AttributedStringSugar.swift
@@ -61,7 +61,7 @@ public extension NSMutableAttributedString {
         if let range = range {
             self.addAttribute(key, value: value, range: range)
         } else {
-            let range = NSRange(location: 0, length: self.string.count)
+            let range = NSRange(location: 0, length: length)
             self.addAttribute(key, value: value, range: range)
         }
         
@@ -86,7 +86,7 @@ public extension NSMutableAttributedString {
         if let range = range {
             self.addAttributes(attrs, range: range)
         } else {
-            let range = NSRange(location: 0, length: self.string.count)
+            let range = NSRange(location: 0, length: length)
             self.addAttributes(attrs, range: range)
         }
         


### PR DESCRIPTION
ลงทะเบียน
하나👨‍👩‍👦‍👦둘

등 composed character 가 포함되었을 경우 기존 default range 는 잘못된 값을 가리키게 됩니다.